### PR TITLE
Fixed color palette

### DIFF
--- a/graficos.bas
+++ b/graficos.bas
@@ -134,6 +134,9 @@ Sub ponpaleta()
 	     	g1=RAM(h) Shr 4
 	     	b1=RAM(h+1) And &h0F
 	     	a1=RAM(h+1) Shr 4
+	     	r1=((r1*a1) Shr 4)
+	     	g1=((g1*a1) Shr 4)
+	     	b1=((b1*a1) Shr 4)
 	     	tintes(g)=RGBA(r1*16,g1*16,b1*16,a1*16)
 	     	Print #1,Chr(9);Chr(9);Hex(r1,2);" , ";Hex(g1,2);" , ";Hex(b1,2);" ,"
 	     	g+=1
@@ -171,6 +174,9 @@ Sub pantalla
 		     	g1=RAM(FF) Shr 4
 		     	b1=RAM(FF+1) And &h0F
 		     	a1=RAM(FF+1) Shr 4
+	     		r1=((r1*a1) Shr 4)
+	     		g1=((g1*a1) Shr 4)
+	     		b1=((b1*a1) Shr 4)
 		     	tinte(CC)=RGBA(r1*16,g1*16,b1*16,a1*16)
 		     	CC+=1
 	   	Next


### PR DESCRIPTION
Amazing work with the emulator, jepalza!  

After doing some research, I fixed the colors.  Star Rider doesn't use RGBA, it actually uses RGB+Luma instead so I looked at how MAME generates the color palette and figured out how to do the same thing in FreeBasic.  

Once we grab the bytes from RAM, we take the R, G, B values, multiply each one by the luma value, then bit-shift right by 4.

![image](https://github.com/user-attachments/assets/f1e410b6-1b45-4271-b6ab-eb5910ebc056)

![image](https://github.com/user-attachments/assets/dcac45a8-a813-4227-bf3d-1025724ad1da)